### PR TITLE
Sedivy/prov constraints for UI

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3337,6 +3337,10 @@ def get_constraints():
         bad_request_error('Invalid entity_type (null) specified. Valid entity_types are source, sample, dataset')
 
     entity_type = payload['entity_type']
+
+    if entity_type == 'sample' and 'sample_category' not in payload:
+        bad_request_error('Invalid sample_category (null) specified. sample_category is required when the entity_type is sample')
+
     if entity_type not in ['source', 'sample', 'dataset']:
         bad_request_error(f'Invalid entity_type ({entity_type}) specified. Valid entity_types are source, sample, '
                           f'dataset')
@@ -3352,7 +3356,7 @@ def get_constraints():
                 result.append(field)
             return jsonify(result)
 
-    return bad_request_error(f"Didn't find an ancestor constraint with the given payload : {payload}")
+    return not_found_error(f"Didn't find an ancestor constraint with the given payload : {payload}")
 
 
 ####################################################################################################

--- a/src/app.py
+++ b/src/app.py
@@ -3329,7 +3329,7 @@ def get_sample_prov_info():
     return jsonify(sample_prov_list)
 
 
-@app.route('/constraints', methods=['GET'])
+@app.route('/constraints', methods=['POST'])
 def get_constraints():
     constraints = constraint_helper.get_constraints()
     payload = request.get_json()

--- a/src/schema/entity-constraints-ui.yaml
+++ b/src/schema/entity-constraints-ui.yaml
@@ -61,7 +61,7 @@ prov_constraints:
         ancestor:
             entity_type: sample
             sample_category: organ
-            value: blood
+            value: BD
         allowable_descendants:
             - field:
                   entity_type: sample

--- a/src/schema/entity-constraints-ui.yaml
+++ b/src/schema/entity-constraints-ui.yaml
@@ -1,0 +1,69 @@
+---
+description: "This file populates the dropdowns on the SenNet UI based on what ancestor the user picks. For example, the user is registering a Sample and picks a Source as an ancestor. The UI will only show the allowable descendants listed under the source constraint"
+prov_constraints:
+    - constraint:
+        description: "An Organ can be a descendant of a Source"
+        ancestor:
+            entity_type: source
+        allowable_descendants:
+            - field:
+                  entity_type: sample
+                  sample_category: [organ]
+    - constraint:
+        description: "A tissue block can be a descendant of an Organ"
+        ancestor:
+            entity_type: sample
+            sample_category: organ
+        allowable_descendants:
+            - field:
+                  entity_type: sample
+                  sample_category: [block]
+    - constraint:
+        description: "A tissue section, tissue block, suspension, and lightsheet can be a descendant of a tissue block"
+        ancestor:
+            entity_type: sample
+            sample_category: block
+        allowable_descendants:
+            - field:
+                  entity_type: sample
+                  sample_category: [ section, block, suspension ]
+            - field:
+                  entity_type: dataset
+                  data_type: [lightsheet]
+    - constraint:
+        description: "A suspension and dataset can be a descendant of a tissue section"
+        ancestor:
+            entity_type: sample
+            sample_category: section
+        allowable_descendants:
+            - field:
+                  entity_type: sample
+                  sample_category: [ suspension ]
+            - field:
+                  entity_type: dataset
+    - constraint:
+        description: "A Dataset can be the descendant of a suspension"
+        ancestor:
+            entity_type: sample
+            sample_category: suspension
+        allowable_descendants:
+            - field:
+                  entity_type: dataset
+    - constraint:
+        description: "A Dataset can be the descendant of another Dataset"
+        ancestor:
+            entity_type: dataset
+        allowable_descendants:
+            - field:
+                  entity_type: dataset
+    - constraint:
+        description: "A suspension can be the direct descendant of an organ of type blood"
+        ancestor:
+            entity_type: sample
+            sample_category: organ
+            value: blood
+        allowable_descendants:
+            - field:
+                  entity_type: sample
+                  sample_category: [suspension]
+

--- a/src/schema/entity-constraints-ui.yaml
+++ b/src/schema/entity-constraints-ui.yaml
@@ -8,7 +8,7 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [Organ]
+                  sample_category: [organ]
     - constraint:
         description: "A tissue block can be a descendant of an Organ"
         ancestor:
@@ -17,7 +17,7 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [Block]
+                  sample_category: [block]
     - constraint:
         description: "A tissue section, tissue block, suspension, and lightsheet can be a descendant of a tissue block"
         ancestor:
@@ -26,10 +26,10 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [ Section, Block, Suspension ]
+                  sample_category: [ section, block, suspension ]
             - field:
                   entity_type: dataset
-                  data_type: [Lightsheet]
+                  data_type: [lightsheet]
     - constraint:
         description: "A suspension and dataset can be a descendant of a tissue section"
         ancestor:
@@ -38,7 +38,7 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [ Suspension ]
+                  sample_category: [ suspension ]
             - field:
                   entity_type: dataset
     - constraint:
@@ -65,5 +65,5 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [Suspension]
+                  sample_category: [suspension]
 

--- a/src/schema/entity-constraints-ui.yaml
+++ b/src/schema/entity-constraints-ui.yaml
@@ -8,7 +8,7 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [organ]
+                  sample_category: [Organ]
     - constraint:
         description: "A tissue block can be a descendant of an Organ"
         ancestor:
@@ -17,7 +17,7 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [block]
+                  sample_category: [Block]
     - constraint:
         description: "A tissue section, tissue block, suspension, and lightsheet can be a descendant of a tissue block"
         ancestor:
@@ -26,10 +26,10 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [ section, block, suspension ]
+                  sample_category: [ Section, Block, Suspension ]
             - field:
                   entity_type: dataset
-                  data_type: [lightsheet]
+                  data_type: [Lightsheet]
     - constraint:
         description: "A suspension and dataset can be a descendant of a tissue section"
         ancestor:
@@ -38,7 +38,7 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [ suspension ]
+                  sample_category: [ Suspension ]
             - field:
                   entity_type: dataset
     - constraint:
@@ -65,5 +65,5 @@ prov_constraints:
         allowable_descendants:
             - field:
                   entity_type: sample
-                  sample_category: [suspension]
+                  sample_category: [Suspension]
 


### PR DESCRIPTION
Added endpoint for the sennet ui to fetch the allowable descendants for an entity. The plan is to replace this endpoint with the ontology-api in the future.