### PR TITLE
Setting detailed processing information in the activity

### DIFF
--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -20,6 +20,9 @@ MEMCACHED_SERVER = 'host:11211'
 # Change prefix based on deployment environment, default for DEV
 MEMCACHED_PREFIX = 'sn_entity_dev_'
 
+# GitHub REST API token
+GITHUB_API_TOKEN = ""
+
 # URL for talking to UUID API (default value used for docker deployment, no token needed)
 # Don't use localhost since uuid-api is running on a different container
 # Point to remote URL for non-docker development

--- a/src/lib/github.py
+++ b/src/lib/github.py
@@ -1,0 +1,92 @@
+from typing import Dict, Optional, Tuple
+
+from flask import current_app
+import requests
+
+
+GH_BASE_URL = 'https://github.com'
+GH_API_BASE_URL = 'https://api.github.com'
+
+COMMONWL_BASE_URL = 'https://view.commonwl.org/workflows'
+
+
+def _get_headers() -> Dict[str, str]:
+    return {
+        'Authorization': f'Bearer {current_app.config["GITHUB_API_TOKEN"]}',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+    }
+
+
+def parse_repo_name(url: str) -> Optional[Tuple[str, str]]:
+    if url is None or len(url) == 0:
+        return None
+
+    url = url.removeprefix(f'{GH_BASE_URL}/')
+    url = url.removesuffix('.git')
+    match = url.split('/')
+    if match is None or len(match) != 2:
+        return None
+    return tuple(match)
+
+
+def get_repo_description(owner: str, repo: str) -> Optional[str]:
+    gh_url = f'{GH_API_BASE_URL}/repos/{owner}/{repo}'
+    res = requests.get(
+        gh_url,
+        headers=_get_headers(),
+    )
+    if res.status_code != 200:
+        return None
+    return res.json()['description']
+
+
+def get_complete_hash(owner: str, repo: str, commit: str) -> Optional[str]:
+    gh_url = f'{GH_API_BASE_URL}/repos/{owner}/{repo}/commits/{commit}'
+    res = requests.get(
+        gh_url,
+        headers=_get_headers(),
+    )
+    if res.status_code != 200:
+        return None
+    return res.json()['sha']
+
+
+def get_tags(owner: str, repo: str) -> Optional[Dict[str, str]]:
+    gh_url = f'{GH_API_BASE_URL}/repos/{owner}/{repo}/tags'
+    res = requests.get(
+        gh_url,
+        headers=_get_headers(),
+    )
+    if res.status_code != 200:
+        return None
+    return {tag['commit']['sha'][:7]: tag['name'] for tag in res.json()}
+
+
+def get_tag(owner: str, repo: str, hash: str) -> Optional[str]:
+    tags = get_tags(owner, repo)
+    if tags is None:
+        return None
+    return tags.get(hash[:7])
+
+
+def create_commit_url(owner: str, repo: str, commit: str) -> Optional[str]:
+    if len(commit) < 40:
+        commit = get_complete_hash(owner, repo, commit)
+
+    if commit is None:
+        return None
+
+    return f'https://github.com/{owner}/{repo}/tree/{commit}'
+
+
+def create_tag_url(owner: str, repo: str, tag: str) -> str:
+    return f'{GH_BASE_URL}/{owner}/{repo}/releases/tag/{tag}'
+
+
+def create_commonwl_url(owner: str, repo: str, commit: str, filename: str) -> str:
+    if len(commit) < 40:
+        cmp_commit = get_complete_hash(owner, repo, commit)
+        if cmp_commit is not None:
+            commit = cmp_commit
+    return f'{COMMONWL_BASE_URL}/github.com/{owner}/{repo}/blob/{commit}/{filename}'

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1,5 +1,3 @@
-import os
-import ast
 import json
 import urllib
 
@@ -14,9 +12,10 @@ import re
 
 # Use the current_app proxy, which points to the application handling the current activity
 from flask import current_app as app
-from lib.ontology import Ontology
 
 # Local modules
+from lib import github
+from lib.ontology import Ontology
 from schema import schema_manager
 from schema import schema_errors
 from schema import schema_neo4j_queries
@@ -56,7 +55,6 @@ def set_timestamp(property_key, normalized_type, user_token, existing_data_dict,
     # Will be proessed in app_neo4j_queries._build_properties_map()
     # and schema_neo4j_queries._build_properties_map()
     return property_key, 'TIMESTAMP()'
-
 
 """
 Trigger event method of setting the entity type of a given entity
@@ -2299,21 +2297,68 @@ str: The processing_information list
 
 
 def set_processing_information(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):
-    if 'entity_type' in new_data_dict and not equals(new_data_dict['entity_type'], 'Dataset'):
-        return property_key, None
-    else:
-        if 'metadata' not in new_data_dict or (
-                'metadata' in new_data_dict and 'dag_provenance_list' not in new_data_dict['metadata']):
-            return property_key, None
+    # Need to hard set `processing_information` as this gets called
+    # when `metadata` is passed in the payload
+    if ('entity_type' in new_data_dict
+            and not equals(new_data_dict['entity_type'], 'Dataset')):
+        return 'processing_information', None
 
-    try:
-        metadata_to_return = {}
-        metadata = schema_manager.convert_str_to_data(new_data_dict['metadata'])
-        metadata_to_return['dag_provenance_list'] = metadata['dag_provenance_list']
-        # Need to hard set `processing_information` as this gets called when `metadata` is passed in the payload
-        return 'processing_information', metadata_to_return
-    except requests.exceptions.RequestException as e:
-        raise requests.exceptions.RequestException(e)
+    if ('metadata' not in new_data_dict
+            or 'dag_provenance_list' not in new_data_dict['metadata']):
+        return 'processing_information', None
+
+    metadata = schema_manager.convert_str_to_data(new_data_dict['metadata'])
+    dag_provs = metadata['dag_provenance_list']
+
+    if len(dag_provs) < 1:
+        # dag_provenance_list is empty
+        return 'processing_information', None
+
+    if any([d.get('hash') is None or d.get('origin') is None for d in dag_provs]):
+        # dag_provenance_list contains invalid entries
+        # entries must have both hash and origin
+        return 'processing_information', None
+
+    proc_info = {
+        'description': '',
+        'pipelines': []
+    }
+    for idx, dag_prov in enumerate(dag_provs):
+        parts = github.parse_repo_name(dag_prov['origin'])
+        if parts is None:
+            continue
+        owner, repo = parts
+
+        if idx == 0 and repo != SchemaConstants.INGEST_PIPELINE_APP:
+            # first entry must be the SenNet ingest pipeline
+            return 'processing_information', None
+
+        if idx > 0 and repo == SchemaConstants.INGEST_PIPELINE_APP:
+            # Ignore duplicate ingest pipeline entries
+            continue
+
+        # Set description to first non ingest pipeline repo
+        if (proc_info.get('description') == ""
+                and repo != SchemaConstants.INGEST_PIPELINE_APP):
+            proc_info['description'] = github.get_repo_description(owner, repo)
+
+        hash = dag_prov['hash']
+        tag = github.get_tag(owner, repo, hash)
+        if tag:
+            url = github.create_tag_url(owner, repo, tag)
+        else:
+            url = github.create_commit_url(owner, repo, hash)
+            if url is None:
+                continue
+        info = {'github': url}
+
+        if 'name' in dag_prov:
+            cwl_url = github.create_commonwl_url(owner, repo, hash, dag_prov['name'])
+            info['commonwl'] = cwl_url
+
+        proc_info['pipelines'].append({repo: info})
+
+    return 'processing_information', proc_info
 
 
 ####################################################################################################

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -2303,11 +2303,14 @@ def set_processing_information(property_key, normalized_type, user_token, existi
             and not equals(new_data_dict['entity_type'], 'Dataset')):
         return 'processing_information', None
 
-    if ('metadata' not in new_data_dict
-            or 'dag_provenance_list' not in new_data_dict['metadata']):
+    metadata = None
+    for key in ['metadata', 'ingest_metadata']:
+        if key in new_data_dict:
+            metadata = schema_manager.convert_str_to_data(new_data_dict[key])
+            break
+    if metadata is None or 'dag_provenance_list' not in metadata:
         return 'processing_information', None
 
-    metadata = schema_manager.convert_str_to_data(new_data_dict['metadata'])
     dag_provs = metadata['dag_provenance_list']
 
     if len(dag_provs) < 1:


### PR DESCRIPTION
The set_processing_information trigger creates links to the GitHub repository hash or tag that was used in the pipeline. The GITHUB_API_TOKEN environment variable must be set to in app.cfg. This key ensures that the request limit is 5000 requests per hour rather than the default 60.

Addresses issue #232 