### PR TITLE
Removing header check for entity updates - #482

### DIFF
--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -234,8 +234,6 @@ shared_entity_properties: &shared_entity_properties
     before_create_trigger: set_entity_type
   metadata:
     type: json_string # dict
-    before_property_create_validators:
-      - validate_application_header_before_property_create
     description: "The metadata returned from the processing at data submission time."
   has_metadata:
     type: string

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -235,9 +235,7 @@ shared_entity_properties: &shared_entity_properties
   metadata:
     type: json_string # dict
     before_property_create_validators:
-      - validate_application_header_before_property_update
-    before_property_update_validators:
-      - validate_application_header_before_property_update
+      - validate_application_header_before_property_create
     description: "The metadata returned from the processing at data submission time."
   has_metadata:
     type: string
@@ -399,7 +397,6 @@ ENTITIES:
       status:
         type: string
         before_property_update_validators:
-          - validate_application_header_before_property_update
           - validate_dataset_status_value
           - validate_status_changed
           - validate_dataset_not_component
@@ -511,10 +508,6 @@ ENTITIES:
         on_index_trigger: get_pipeline_message_reduced
       ingest_metadata:
         type: json_string # dict
-        before_property_create_validators:
-          - validate_application_header_before_property_update
-        before_property_update_validators:
-          - validate_application_header_before_property_update
         description: "The metadata returned from the processing at data submission time."
       local_directory_rel_path:
         # Example: protected/<TMC>/<uuid>
@@ -1169,7 +1162,6 @@ ENTITIES:
         description: "Title of the datasets, a sentence or less"
       status:
         before_property_update_validators:
-          - validate_application_header_before_property_update
           - validate_upload_status_value
         type: string
         generated: true

--- a/src/schema/schema_constants.py
+++ b/src/schema/schema_constants.py
@@ -29,6 +29,9 @@ class SchemaConstants(object):
     ALLOWED_DATASET_STATUSES = ['new', 'processing', 'published', 'qa', 'error', 'hold', 'invalid', 'submitted', 'incomplete']
     ALLOWED_UPLOAD_STATUSES = ['new', 'valid', 'invalid', 'error', 'reorganized', 'processing', 'submitted', 'incomplete']
 
+    # Used to validate the X-SenNet-Application header
+    ALLOWED_APPLICATIONS = [INGEST_API_APP, INGEST_PIPELINE_APP, INGEST_PORTAL_APP]
+
 
 # Define an enumeration to classify an entity's visibility, which can be combined with
 # authorization info when verify operations on a request.
@@ -37,6 +40,7 @@ class DataVisibilityEnum(Enum):
     # Since initial release just requires public/non-public, add
     # another entry indicating non-public.
     NONPUBLIC = 'nonpublic'
+
 
 # Define an enumeration to classify metadata scope which can be returned.
 class MetadataScopeEnum(Enum):
@@ -47,6 +51,7 @@ class MetadataScopeEnum(Enum):
     # include data which must be generated and then removed, nor any data which
     # is not stored in an index document.
     INDEX = 'index_metadata'
+
 
 # Define an enumeration of accepted trigger types.
 class TriggerTypeEnum(Enum):

--- a/src/schema/schema_validators.py
+++ b/src/schema/schema_validators.py
@@ -31,10 +31,7 @@ def validate_application_header_before_entity_create(normalized_entity_type, req
     # Currently only ingest-api and ingest-pipeline are allowed
     # to create or update Dataset and Upload
     # Use lowercase for comparison
-    applications_allowed = [SchemaConstants.INGEST_API_APP, SchemaConstants.INGEST_PIPELINE_APP,
-                            SchemaConstants.INGEST_PORTAL_APP]
-
-    _validate_application_header(applications_allowed, request.headers)
+    _validate_application_header(SchemaConstants.ALLOWED_APPLICATIONS, request.headers)
 
 
 ##############################################################################################
@@ -241,16 +238,13 @@ new_data_dict : dict
 """
 
 
-def validate_application_header_before_property_update(property_key, normalized_entity_type, request,
+def validate_application_header_before_property_create(property_key, normalized_entity_type, request,
                                                        existing_data_dict, new_data_dict):
     # A list of applications allowed to update this property
     # Currently only ingest-api, ingest-pipeline, and portal-ui are allowed
     # to update Dataset.status or Upload.status
     # Use lowercase for comparison
-    applications_allowed = [SchemaConstants.INGEST_API_APP, SchemaConstants.INGEST_PIPELINE_APP,
-                            SchemaConstants.INGEST_PORTAL_APP]
-
-    _validate_application_header(applications_allowed, request.headers)
+    _validate_application_header(SchemaConstants.ALLOWED_APPLICATIONS, request.headers)
 
 
 """


### PR DESCRIPTION
Changes
- Removed `before_property_update_validators` that validate the application header
- Created `ALLOWED_APPLICATIONS` schema constant