### PR TITLE
Checking entities visibility for collections

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4618,14 +4618,13 @@ def get_collections(id):
     # Get the entity dict from cache if exists
     # Otherwise query against uuid-api and neo4j to get the entity dict if the id exists
     entity_dict = query_target_entity(id)
-    normalized_entity_type = entity_dict['entity_type']
     uuid = entity_dict['uuid']
     public_entity = True
 
-    if not schema_manager.entity_type_instanceof(normalized_entity_type, 'Dataset'):
-        abort_bad_req(f"Unsupported entity type of id {id}: {normalized_entity_type}")
+    entity_scope = _get_entity_visibility(normalized_entity_type=entity_dict['entity_type'],
+                                          entity_dict=entity_dict)
 
-    if entity_dict['status'].lower() != DATASET_STATUS_PUBLISHED:
+    if entity_scope == DataVisibilityEnum.NON_PUBLIC:
         # Token is required and the user must belong to HuBMAP-READ group
         token = get_user_token(request, non_public_access_required=True)
         public_entity = False


### PR DESCRIPTION
Changes
- Removed requirement that entity needs to be a Dataset for `entities/<id>/collections` endpoint
- Added check for entity visibility