### PR TITLE
Libpitt/556 origin samples

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4937,7 +4937,8 @@ def get_datasets_for_upload(id: str):
         "pipeline_message",
         "status_history"
     ]
-    datasets = schema_triggers.get_normalized_upload_datasets(entity_dict["uuid"], properties_to_exclude)
+    token = get_internal_token()
+    datasets = schema_triggers.get_normalized_upload_datasets(entity_dict["uuid"], token, properties_to_exclude)
     return jsonify(datasets)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -4935,7 +4935,11 @@ def get_datasets_for_upload(id: str):
         "ingest_metadata",
         "ingest_task",
         "pipeline_message",
-        "status_history"
+        "status_history",
+        "direct_ancestors",
+        "metadata",
+        "sources",
+        "upload"
     ]
     token = get_internal_token()
     datasets = schema_triggers.get_normalized_upload_datasets(entity_dict["uuid"], token, properties_to_exclude)

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -2972,6 +2972,8 @@ def get_normalized_upload_datasets(uuid: str, token, properties_to_exclude: List
     ----------
     uuid : str
         The UUID of the Upload entity
+    token: str
+        Either the user's globus nexus token or the internal token
     properties_to_exclude : List[str]
         A list of property keys to exclude from the normalized results
 

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -2961,11 +2961,11 @@ def get_upload_datasets(property_key: str, normalized_type: str, user_token: str
 
     logger.info(f"Executing 'get_upload_datasets()' trigger method on uuid: {existing_data_dict['uuid']}")
 
-    upload_datasets = get_normalized_upload_datasets(existing_data_dict["uuid"])
+    upload_datasets = get_normalized_upload_datasets(existing_data_dict["uuid"], user_token)
     return property_key, upload_datasets
 
 
-def get_normalized_upload_datasets(uuid: str, properties_to_exclude: List[str] = []):
+def get_normalized_upload_datasets(uuid: str, token, properties_to_exclude: List[str] = []):
     """Query the Neo4j database to get the associated datasets for a given Upload UUID and normalize the results.
 
     Parameters
@@ -2982,9 +2982,15 @@ def get_normalized_upload_datasets(uuid: str, properties_to_exclude: List[str] =
     db = schema_manager.get_neo4j_driver_instance()
     datasets_list = schema_neo4j_queries.get_upload_datasets(db, uuid)
 
+
+    complete_list = []
+    for dataset in datasets_list:
+        complete_dict = schema_manager.get_complete_entity_result(token, dataset)
+        complete_list.append(complete_dict)
+
     # Get rid of the entity node properties that are not defined in the yaml schema
     # as well as the ones defined as `exposed: false` in the yaml schema
-    return schema_manager.normalize_entities_list_for_response(datasets_list,
+    return schema_manager.normalize_entities_list_for_response(complete_list,
                                                                properties_to_exclude=properties_to_exclude)
 
 


### PR DESCRIPTION
The return of the complete dataset dict wasn't handled, so none of the triggers for transient properties were actually called

Change log:
1. Call `schema_manager.get_complete_entity_result` on each dataset
2. Pass token to method `get_normalized_upload_datasets`
