### PR TITLE
Libpitt/606 grabbing activity props

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1706,17 +1706,8 @@ def get_ancestors(id):
         complete_entities_list = schema_manager.get_complete_entities_list(token, ancestors_list, properties_to_skip)
 
         # Final result after normalization
-        final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=['protocol_url'])
-
-        if public_entity and not user_in_sennet_read_group(request):
-            filtered_final_result = []
-            for ancestor in final_result:
-                ancestor_entity_type = ancestor.get('entity_type')
-                fields_to_exclude = schema_manager.get_fields_to_exclude(ancestor_entity_type)
-                filtered_ancestor = schema_manager.exclude_properties_from_response(fields_to_exclude, ancestor)
-                filtered_final_result.append(filtered_ancestor)
-
-            final_result = filtered_final_result
+        _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=['protocol_url'])
+        final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not authorized)
 
     return jsonify(final_result)
 
@@ -1829,17 +1820,8 @@ def get_descendants(id):
         complete_entities_list = schema_manager.get_complete_entities_list(token, descendants_list, properties_to_skip)
 
         # Final result after normalization
-        final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=['protocol_url'])
-
-        if public_entity and not authorized:
-            filtered_final_result = []
-            for ancestor in final_result:
-                ancestor_entity_type = ancestor.get('entity_type')
-                fields_to_exclude = schema_manager.get_fields_to_exclude(ancestor_entity_type)
-                filtered_ancestor = schema_manager.exclude_properties_from_response(fields_to_exclude, ancestor)
-                filtered_final_result.append(filtered_ancestor)
-
-            final_result = filtered_final_result
+        _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=['protocol_url'])
+        final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not authorized)
 
     return jsonify(final_result)
 
@@ -2062,7 +2044,8 @@ def get_children(id):
         complete_entities_list = schema_manager.get_complete_entities_list(user_token, children_list, properties_to_skip)
 
         # Final result after normalization
-        final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+        _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+        final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
 
     return jsonify(final_result)
 

--- a/src/app.py
+++ b/src/app.py
@@ -962,9 +962,6 @@ def get_entities_by_type(entity_type):
             abort_bad_req("The specified query string is not supported. Use '?property=<key>' to filter the result")
     # Return all the details if no property filtering
     else:
-        # Get back a list of entity dicts for the given entity type
-        entities_list = app_neo4j_queries.get_entities_by_type(neo4j_driver_instance, normalized_entity_type)
-
         # We'll return all the properties but skip these time-consuming ones
         # Source doesn't need to skip any
         # Collection is not handled by this call
@@ -1677,19 +1674,11 @@ def get_ancestors(id):
                 abort_bad_req("Missing required key: filter_properties")
             if 'filter_properties' in filtering_dict:
                 properties_action = filtering_dict.get('is_include', True)
-
-                # Need to manually check for protocol_url
-                include_protocol = False
-                protocol_properties = []
-                if 'protocol_url' in filtering_dict['filter_properties'] and properties_action:
-                    include_protocol = True
-                    protocol_properties = ['protocol_url']
-
                 segregated_properties = schema_manager.group_verify_properties_list(properties=filtering_dict['filter_properties'])
-                property_list = app_neo4j_queries.get_ancestors(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action, include_protocol=include_protocol)
+                property_list = app_neo4j_queries.get_ancestors(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=protocol_properties)
+                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
 
     # Return all the details if no property filtering
     else:
@@ -1809,19 +1798,11 @@ def get_descendants(id):
                 abort_bad_req("Missing required key: filter_properties")
             if 'filter_properties' in filtering_dict:
                 properties_action = filtering_dict.get('is_include', True)
-
-                # Need to manually check for protocol_url
-                include_protocol = False
-                protocol_properties = []
-                if 'protocol_url' in filtering_dict['filter_properties'] and properties_action:
-                    include_protocol = True
-                    protocol_properties = ['protocol_url']
-
                 segregated_properties = schema_manager.group_verify_properties_list(properties=filtering_dict['filter_properties'])
-                property_list = app_neo4j_queries.get_descendants(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action,  include_protocol=include_protocol)
+                property_list = app_neo4j_queries.get_descendants(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=protocol_properties)
+                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
     # Return all the details if no property filtering
     else:
         descendants_list = app_neo4j_queries.get_descendants(neo4j_driver_instance, uuid, data_access_level,

--- a/src/app.py
+++ b/src/app.py
@@ -1686,8 +1686,8 @@ def get_ancestors(id):
                     protocol_properties = ['protocol_url']
 
                 segregated_properties = schema_manager.group_verify_properties_list(properties=filtering_dict['filter_properties'])
-                property_list = app_neo4j_queries.get_ancestors(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties[0] + segregated_properties[2], is_include_action=properties_action, include_protocol=include_protocol)
-                complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties[1], is_include_action=properties_action)
+                property_list = app_neo4j_queries.get_ancestors(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action, include_protocol=include_protocol)
+                complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
                 final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=protocol_properties)
 
@@ -1818,8 +1818,8 @@ def get_descendants(id):
                     protocol_properties = ['protocol_url']
 
                 segregated_properties = schema_manager.group_verify_properties_list(properties=filtering_dict['filter_properties'])
-                property_list = app_neo4j_queries.get_descendants(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties[0] + segregated_properties[2], is_include_action=properties_action,  include_protocol=include_protocol)
-                complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties[1], is_include_action=properties_action)
+                property_list = app_neo4j_queries.get_descendants(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action,  include_protocol=include_protocol)
+                complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
                 final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=protocol_properties)
     # Return all the details if no property filtering
@@ -1948,8 +1948,8 @@ def get_parents(id):
             if 'filter_properties' in filtering_dict:
                 properties_action = filtering_dict.get('is_include', True)
                 segregated_properties = schema_manager.group_verify_properties_list(properties=filtering_dict['filter_properties'])
-                property_list = app_neo4j_queries.get_parents(neo4j_driver_instance, uuid, properties=segregated_properties[0] + segregated_properties[2], is_include_action=properties_action)
-                complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties[1], is_include_action=properties_action)
+                property_list = app_neo4j_queries.get_parents(neo4j_driver_instance, uuid, properties=segregated_properties, is_include_action=properties_action)
+                complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
                 final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
     # Return all the details if no property filtering
@@ -2050,8 +2050,8 @@ def get_children(id):
             if 'filter_properties' in filtering_dict:
                 properties_action = filtering_dict.get('is_include', True)
                 segregated_properties = schema_manager.group_verify_properties_list(properties=filtering_dict['filter_properties'])
-                property_list = app_neo4j_queries.get_children(neo4j_driver_instance, uuid, properties=segregated_properties[0] + segregated_properties[2], is_include_action=properties_action)
-                complete_entities_list = schema_manager.get_complete_entities_list(user_token, property_list, segregated_properties[1], is_include_action=properties_action)
+                property_list = app_neo4j_queries.get_children(neo4j_driver_instance, uuid, properties=segregated_properties, is_include_action=properties_action)
+                complete_entities_list = schema_manager.get_complete_entities_list(user_token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
                 final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
     # Return all the details if no property filtering
@@ -5033,9 +5033,9 @@ def get_datasets_for_upload(id: str):
             if 'filter_properties' in filtering_dict:
                 properties_to_filter = filtering_dict['filter_properties']
                 segregated_properties = schema_manager.group_verify_properties_list(Ontology.ops().entities().DATASET, properties_to_filter)
-                neo4j_properties_to_filter = segregated_properties[0] + segregated_properties[2]
+                neo4j_properties_to_filter = segregated_properties.neo4j + segregated_properties.dependency
                 properties_action = filtering_dict.get('is_include', True)
-                properties_to_exclude = properties_to_exclude + segregated_properties[1] if properties_action is False else segregated_properties[1]
+                properties_to_exclude = properties_to_exclude + segregated_properties.trigger if properties_action is False else segregated_properties.trigger
 
     token = get_internal_token()
     datasets = schema_triggers.get_normalized_upload_datasets(entity_dict["uuid"], token, properties_to_exclude, properties=neo4j_properties_to_filter,

--- a/src/app.py
+++ b/src/app.py
@@ -1678,7 +1678,8 @@ def get_ancestors(id):
                 property_list = app_neo4j_queries.get_ancestors(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not authorized)
 
     # Return all the details if no property filtering
     else:
@@ -1802,7 +1803,8 @@ def get_descendants(id):
                 property_list = app_neo4j_queries.get_descendants(neo4j_driver_instance, uuid, data_access_level, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not authorized)
     # Return all the details if no property filtering
     else:
         descendants_list = app_neo4j_queries.get_descendants(neo4j_driver_instance, uuid, data_access_level,
@@ -1932,7 +1934,8 @@ def get_parents(id):
                 property_list = app_neo4j_queries.get_parents(neo4j_driver_instance, uuid, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
     # Return all the details if no property filtering
     else:
         parents_list = app_neo4j_queries.get_parents(neo4j_driver_instance, uuid)
@@ -2034,7 +2037,8 @@ def get_children(id):
                 property_list = app_neo4j_queries.get_children(neo4j_driver_instance, uuid, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(user_token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
+                final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
     # Return all the details if no property filtering
     else:
         children_list = app_neo4j_queries.get_children(neo4j_driver_instance, uuid)

--- a/src/app.py
+++ b/src/app.py
@@ -1932,7 +1932,7 @@ def get_parents(id):
                 property_list = app_neo4j_queries.get_parents(neo4j_driver_instance, uuid, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
     # Return all the details if no property filtering
     else:
         parents_list = app_neo4j_queries.get_parents(neo4j_driver_instance, uuid)
@@ -2034,7 +2034,7 @@ def get_children(id):
                 property_list = app_neo4j_queries.get_children(neo4j_driver_instance, uuid, properties=segregated_properties, is_include_action=properties_action)
                 complete_entities_list = schema_manager.get_complete_entities_list(user_token, property_list, segregated_properties.trigger, is_include_action=properties_action)
                 # Final result
-                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+                final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list, properties_to_include=segregated_properties.activity)
     # Return all the details if no property filtering
     else:
         children_list = app_neo4j_queries.get_children(neo4j_driver_instance, uuid)

--- a/src/app.py
+++ b/src/app.py
@@ -1943,18 +1943,8 @@ def get_parents(id):
         complete_entities_list = schema_manager.get_complete_entities_list(token, parents_list, properties_to_skip)
 
         # Final result after normalization
-        final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
-
-        filtered_final_result = []
-        for parent in final_result:
-            parent_entity_type = parent.get('entity_type')
-            fields_to_exclude = schema_manager.get_fields_to_exclude(parent_entity_type)
-            if public_entity and not user_in_sennet_read_group(request):
-                filtered_parent = schema_manager.exclude_properties_from_response(fields_to_exclude, parent)
-                filtered_final_result.append(filtered_parent)
-            else:
-                filtered_final_result.append(parent)
-        final_result = filtered_final_result
+        _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+        final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
 
     return jsonify(final_result)
 

--- a/src/app.py
+++ b/src/app.py
@@ -2154,18 +2154,8 @@ def get_siblings(id):
 
     complete_entities_list = schema_manager.get_complete_entities_list(token, sibling_list, properties_to_skip)
     # Final result after normalization
-    final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
-
-    filtered_final_result = []
-    for sibling in final_result:
-        sibling_entity_type = sibling.get('entity_type')
-        fields_to_exclude = schema_manager.get_fields_to_exclude(sibling_entity_type)
-        if public_entity and not user_in_sennet_read_group(request):
-            filtered_sibling = schema_manager.exclude_properties_from_response(fields_to_exclude, sibling)
-            filtered_final_result.append(filtered_sibling)
-        else:
-            filtered_final_result.append(sibling)
-    final_result = filtered_final_result
+    _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+    final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
 
     return jsonify(final_result)
 
@@ -2274,18 +2264,8 @@ def get_tuplets(id):
 
     complete_entities_list = schema_manager.get_complete_entities_list(token, tuplet_list, properties_to_skip)
     # Final result after normalization
-    final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
-
-    filtered_final_result = []
-    for tuplet in final_result:
-        tuple_entity_type = tuplet.get('entity_type')
-        fields_to_exclude = schema_manager.get_fields_to_exclude(tuple_entity_type)
-        if public_entity and not user_in_sennet_read_group(request):
-            filtered_tuplet = schema_manager.exclude_properties_from_response(fields_to_exclude, tuplet)
-            filtered_final_result.append(filtered_tuplet)
-        else:
-            filtered_final_result.append(tuplet)
-    final_result = filtered_final_result
+    _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+    final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
 
     return jsonify(final_result)
 
@@ -3140,7 +3120,6 @@ def get_associated_samples_from_dataset(id):
     # Query target entity against uuid-api and neo4j and return as a dict if exists
     entity_dict = query_target_entity(id)
     normalized_entity_type = entity_dict['entity_type']
-    excluded_fields = schema_manager.get_fields_to_exclude('Sample')
 
     # Only for Dataset
     if not schema_manager.entity_type_instanceof(normalized_entity_type, 'Dataset'):
@@ -3168,13 +3147,8 @@ def get_associated_samples_from_dataset(id):
     complete_entities_list = schema_manager.get_complete_entities_list(token, associated_samples)
 
     # Final result after normalization
-    final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
-
-    if public_entity and not user_in_sennet_read_group(request):
-        filtered_sample_list = []
-        for sample in final_result:
-            filtered_sample_list.append(schema_manager.exclude_properties_from_response(excluded_fields, sample))
-        final_result = filtered_sample_list
+    _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+    final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
 
     return jsonify(final_result)
 
@@ -3203,7 +3177,6 @@ def get_associated_sources_from_dataset(id):
     # Query target entity against uuid-api and neo4j and return as a dict if exists
     entity_dict = query_target_entity(id)
     normalized_entity_type = entity_dict['entity_type']
-    excluded_fields = schema_manager.get_fields_to_exclude('Source')
 
     # Only for Dataset
     if not schema_manager.entity_type_instanceof(normalized_entity_type, 'Dataset'):
@@ -3231,13 +3204,8 @@ def get_associated_sources_from_dataset(id):
     complete_entities_list = schema_manager.get_complete_entities_list(token, associated_sources)
 
     # Final result after normalization
-    final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
-
-    if public_entity and not user_in_sennet_read_group(request):
-        filtered_donor_list = []
-        for donor in final_result:
-            filtered_donor_list.append(schema_manager.exclude_properties_from_response(excluded_fields, donor))
-        final_result = filtered_donor_list
+    _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
+    final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
 
     return jsonify(final_result)
 

--- a/src/app_neo4j_queries.py
+++ b/src/app_neo4j_queries.py
@@ -558,7 +558,7 @@ def get_ancestors(neo4j_driver, uuid, data_access_level=None, properties: Union[
         The uuid of target entity
     data_access_level : Optional[str]
         The data access level of the ancestor entities (public or consortium). None returns all ancestors.
-    properties : List[str]
+    properties : Union[PropertyGroups, List[str]]
         A list of property keys to filter in or out from the normalized results, default is []
     is_include_action : bool
         Whether to include or exclude the listed properties
@@ -576,10 +576,9 @@ def get_ancestors(neo4j_driver, uuid, data_access_level=None, properties: Union[
 
     is_filtered = isinstance(properties, PropertyGroups) or  isinstance(properties, list)
     if is_filtered:
-        _activity_query_part = schema_neo4j_queries.activity_query_part(properties)
         query = (f"MATCH (e:Entity)-[:USED|WAS_GENERATED_BY*]->(t:Entity) "
-                 f"WHERE e.uuid = '{uuid}' AND t.entity_type <> 'Lab' {predicate} {_activity_query_part[0]} "
-                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
+                 f"WHERE e.uuid = '{uuid}' AND t.entity_type <> 'Lab' {predicate} "
+                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action)}")
     else:
         _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
         query = (f"MATCH (e:Entity)-[:USED|WAS_GENERATED_BY*]->(t:Entity) "
@@ -630,11 +629,10 @@ def get_descendants(neo4j_driver, uuid, data_access_level=None, entity_type=None
 
     is_filtered = isinstance(properties, PropertyGroups) or isinstance(properties, list)
     if is_filtered:
-        _activity_query_part = schema_neo4j_queries.activity_query_part(properties)
         query = (f"MATCH (e:Entity)<-[:USED|WAS_GENERATED_BY*]-(t:Entity) "
                  # The target entity can't be a Lab
-                 f"WHERE e.uuid=$uuid AND e.entity_type <> 'Lab' {predicate} {_activity_query_part[0]} "
-                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
+                 f"WHERE e.uuid=$uuid AND e.entity_type <> 'Lab' {predicate} "
+                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action)}")
     else:
         _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
         query = (f"MATCH (e:Entity)<-[:USED|WAS_GENERATED_BY*]-(t:Entity) "
@@ -856,11 +854,10 @@ def get_parents(neo4j_driver, uuid, properties: Union[PropertyGroups, List[str]]
 
     is_filtered = isinstance(properties, PropertyGroups) or  isinstance(properties, list)
     if is_filtered:
-        _activity_query_part = schema_neo4j_queries.activity_query_part(properties if is_include_action else None)
         query = (f"MATCH (e:Entity)-[:WAS_GENERATED_BY]->(:Activity)-[:USED]->(t:Entity) "
                  # Filter out the Lab entities
-                 f"WHERE e.uuid='{uuid}' AND t.entity_type <> 'Lab' {_activity_query_part[0]} "
-                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
+                 f"WHERE e.uuid='{uuid}' AND t.entity_type <> 'Lab' "
+                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action)}")
     else:
         _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
         query = (f"MATCH (e:Entity)-[:WAS_GENERATED_BY]->(:Activity)-[:USED]->(t:Entity) "
@@ -905,11 +902,10 @@ def get_children(neo4j_driver, uuid, properties: Union[PropertyGroups, List[str]
 
     is_filtered = isinstance(properties, PropertyGroups) or  isinstance(properties, list)
     if is_filtered:
-        _activity_query_part = schema_neo4j_queries.activity_query_part(properties if is_include_action else None)
         query = (f"MATCH (e:Entity)<-[:USED]-(:Activity)<-[:WAS_GENERATED_BY]-(t:Entity) "
                  # The target entity can't be a Lab
-                 f"WHERE e.uuid='{uuid}' AND e.entity_type <> 'Lab' {_activity_query_part[0]}"
-                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
+                 f"WHERE e.uuid='{uuid}' AND e.entity_type <> 'Lab' "
+                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action)}")
     else:
         _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
         query = (f"MATCH (e:Entity)<-[:USED]-(:Activity)<-[:WAS_GENERATED_BY]-(t:Entity) "

--- a/src/app_neo4j_queries.py
+++ b/src/app_neo4j_queries.py
@@ -1,7 +1,6 @@
 import logging
 
 from atlas_consortia_commons.object import enum_val
-from atlas_consortia_commons.string import equals
 from neo4j.exceptions import TransactionError
 
 from lib.ontology import Ontology
@@ -9,7 +8,7 @@ from lib.property_groups import PropertyGroups
 from schema import schema_neo4j_queries
 from typing import List, Union
 
-from schema.schema_neo4j_queries import activity_query_part
+import schema.schema_manager
 
 logger = logging.getLogger(__name__)
 
@@ -129,44 +128,6 @@ def get_activity(neo4j_driver, uuid):
 
 
 """
-Get the protocol_url from a related activity node
-
-Parameters
-----------
-neo4j_driver : neo4j.Driver object
-    The neo4j database connection pool
-uuid : str
-    The uuid of entity that connects to the activity that contains the protocol_url
-
-Returns
--------
-str
-    The protocol_url property
-"""
-
-
-def get_activity_protocol(neo4j_driver, uuid):
-    result = {}
-
-    query = (f"MATCH (e:Entity)-[:WAS_GENERATED_BY]->(a:Activity)"
-             f"WHERE e.uuid = '{uuid}' "
-             f"RETURN a.protocol_url AS protocol_url")
-
-    logger.debug("======get_activity() query======")
-    logger.debug(query)
-
-    with neo4j_driver.session() as session:
-        record = session.read_transaction(_execute_readonly_tx, query)
-
-        if record is not None:
-            if record[0] is not None:
-                if record:
-                    result = record[0]
-
-    return result
-
-
-"""
 Get target entity dict
 
 Parameters
@@ -186,9 +147,10 @@ dict
 def get_entity(neo4j_driver, uuid):
     result = {}
 
-    query = (f"MATCH (e:Entity) "
-             f"WHERE e.uuid = '{uuid}' "
-             f"RETURN e AS {record_field_name}")
+    _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
+    query = (f"MATCH (t:Entity) "
+             f"WHERE t.uuid = '{uuid}' "
+             f"{_activity_query_part} {record_field_name}")
 
     logger.info("======get_entity() query======")
     logger.info(query)
@@ -196,13 +158,10 @@ def get_entity(neo4j_driver, uuid):
     with neo4j_driver.session() as session:
         record = session.read_transaction(_execute_readonly_tx, query)
 
-        if record and record[record_field_name]:
+        if record and record[record_field_name] and len(record[record_field_name]) > 0:
             # Convert the neo4j node into Python dict
-            result = _node_to_dict(record[record_field_name])
+            result = record[record_field_name][0]
 
-            protocol_url = get_activity_protocol(neo4j_driver, result['uuid'])
-            if protocol_url != {}:
-                result['protocol_url'] = protocol_url
 
     return result
 
@@ -272,10 +231,9 @@ def get_entities_by_type(neo4j_driver, entity_type, property_key=None):
                  # apoc.coll.toSet() reruns a set containing unique nodes
                  f"RETURN apoc.coll.toSet(COLLECT(e.{property_key})) AS {record_field_name}")
     else:
-        query = (f"MATCH (e:{entity_type}) "
-                 # COLLECT() returns a list
-                 # apoc.coll.toSet() reruns a set containing unique nodes
-                 f"RETURN apoc.coll.toSet(COLLECT(e)) AS {record_field_name}")
+        _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
+        query = (f"MATCH (t:{entity_type}) "
+                 f"{_activity_query_part} {record_field_name}")
 
     logger.info("======get_entities_by_type() query======")
     logger.info(query)
@@ -284,18 +242,7 @@ def get_entities_by_type(neo4j_driver, entity_type, property_key=None):
         record = session.read_transaction(_execute_readonly_tx, query)
 
         if record and record[record_field_name]:
-            if property_key:
-                # Just return the list of property values from each entity node
-                results = record[record_field_name]
-            else:
-                # Convert the list of nodes to a list of dicts
-                results = _nodes_to_dicts(record[record_field_name])
-
-    if not property_key:
-        for result in results:
-            protocol_url = get_activity_protocol(neo4j_driver, result['uuid'])
-            if protocol_url != {}:
-                result['protocol_url'] = protocol_url
+            results = record[record_field_name]
 
     return results
 
@@ -600,7 +547,7 @@ def update_entity(neo4j_driver, entity_type, entity_data_dict, uuid):
         raise TransactionError(msg)
 
 
-def get_ancestors(neo4j_driver, uuid, data_access_level=None, properties: Union[PropertyGroups, List[str]] = None, is_include_action: bool = True, include_protocol = False):
+def get_ancestors(neo4j_driver, uuid, data_access_level=None, properties: Union[PropertyGroups, List[str]] = None, is_include_action: bool = True):
     """Get all ancestors by uuid.
 
     Parameters
@@ -634,12 +581,11 @@ def get_ancestors(neo4j_driver, uuid, data_access_level=None, properties: Union[
                  f"WHERE e.uuid = '{uuid}' AND t.entity_type <> 'Lab' {predicate} {_activity_query_part[0]} "
                  f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
     else:
+        _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
         query = (f"MATCH (e:Entity)-[:USED|WAS_GENERATED_BY*]->(t:Entity) "
                  # Filter out the Lab entities
                  f"WHERE e.uuid='{uuid}' AND t.entity_type <> 'Lab' {predicate}"
-                 # COLLECT() returns a list
-                 # apoc.coll.toSet() reruns a set containing unique nodes
-                 f"RETURN apoc.coll.toSet(COLLECT(t)) AS {record_field_name}")
+                 f"{_activity_query_part} {record_field_name}")
 
     logger.info("======get_ancestors() query======")
     logger.info(query)
@@ -648,27 +594,12 @@ def get_ancestors(neo4j_driver, uuid, data_access_level=None, properties: Union[
         record = session.read_transaction(_execute_readonly_tx, query)
 
         if record and record[record_field_name]:
-            if is_filtered:
-                # Just return the list of property values from each entity node
-                results = record[record_field_name]
-                if include_protocol:
-                    for result in results:
-                        protocol_url = get_activity_protocol(neo4j_driver, result['uuid'])
-                        if protocol_url != {}:
-                            result['protocol_url'] = protocol_url
-            else:
-                # Convert the list of nodes to a list of dicts
-                results = _nodes_to_dicts(record[record_field_name])
-
-                for result in results:
-                    protocol_url = get_activity_protocol(neo4j_driver, result['uuid'])
-                    if protocol_url != {}:
-                        result['protocol_url'] = protocol_url
+            results = record[record_field_name]
 
     return results
 
 
-def get_descendants(neo4j_driver, uuid, data_access_level=None, entity_type=None, properties: Union[PropertyGroups, List[str]] = None, is_include_action: bool = True, include_protocol = False):
+def get_descendants(neo4j_driver, uuid, data_access_level=None, entity_type=None, properties: Union[PropertyGroups, List[str]] = None, is_include_action: bool = True):
     """ Get all descendants by uuid
 
     Parameters
@@ -697,20 +628,19 @@ def get_descendants(neo4j_driver, uuid, data_access_level=None, entity_type=None
     if data_access_level:
         predicate = f"AND (t.status='Published' OR t.data_access_level = '{data_access_level}') "
 
-    is_filtered = isinstance(properties, PropertyGroups) or  isinstance(properties, list)
+    is_filtered = isinstance(properties, PropertyGroups) or isinstance(properties, list)
     if is_filtered:
         _activity_query_part = schema_neo4j_queries.activity_query_part(properties)
         query = (f"MATCH (e:Entity)<-[:USED|WAS_GENERATED_BY*]-(t:Entity) "
                  # The target entity can't be a Lab
                  f"WHERE e.uuid=$uuid AND e.entity_type <> 'Lab' {predicate} {_activity_query_part[0]} "
-                 f"{schema_neo4j_queries.exclude_include_query_part(properties.neo4j + properties.dependency, is_include_action, more_to_grab_query_part=_activity_query_part)}")
+                 f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
     else:
+        _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
         query = (f"MATCH (e:Entity)<-[:USED|WAS_GENERATED_BY*]-(t:Entity) "
                  # The target entity can't be a Lab
                  f"WHERE e.uuid=$uuid AND e.entity_type <> 'Lab' {predicate}"
-                 # COLLECT() returns a list
-                 # apoc.coll.toSet() reruns a set containing unique nodes
-                 f"RETURN apoc.coll.toSet(COLLECT(t)) AS {record_field_name}")
+                 f"{_activity_query_part} {record_field_name}")
 
     logger.info("======get_descendants() query======")
     logger.info(query)
@@ -719,32 +649,10 @@ def get_descendants(neo4j_driver, uuid, data_access_level=None, entity_type=None
         record = session.read_transaction(_execute_readonly_tx, query, uuid=uuid)
 
         if record and record[record_field_name]:
-            if is_filtered:
-                # Just return the list of property values from each entity node
-                results = record[record_field_name]
-                if include_protocol:
-                    for result in results:
-                        protocol_url = get_activity_protocol(neo4j_driver, result['uuid'])
-                        if protocol_url != {}:
-                            result['protocol_url'] = protocol_url
-            else:
-                # Convert the list of nodes to a list of dicts
-                results = _nodes_to_dicts(record[record_field_name])
+            results = record[record_field_name]
 
-                # If asked for the descendants of a Dataset then sort by last_modified_timestamp and place the published dataset at the top
-                if equals(entity_type,  Ontology.ops().entities().DATASET):
-                    results = sorted(results, key=lambda d: d['last_modified_timestamp'], reverse=True)
+            schema.schema_manager.rearrange_datasets(results, entity_type)
 
-                    published_processed_dataset_location = next(
-                        (i for i, item in enumerate(results) if item["status"] == "Published"), None)
-                    if published_processed_dataset_location and published_processed_dataset_location != 0:
-                        published_processed_dataset = results.pop(published_processed_dataset_location)
-                        results.insert(0, published_processed_dataset)
-
-                for result in results:
-                    protocol_url = get_activity_protocol(neo4j_driver, result['uuid'])
-                    if protocol_url != {}:
-                        result['protocol_url'] = protocol_url
 
     return results
 
@@ -776,12 +684,11 @@ def get_descendant_datasets(neo4j_driver, uuid, property_key=None):
                  # apoc.coll.toSet() reruns a set containing unique nodes
                  f"RETURN apoc.coll.toSet(COLLECT(descendant.{property_key})) AS {record_field_name}")
     else:
-        query = (f"MATCH (e:Entity)<-[:USED|WAS_GENERATED_BY*]-(descendant:Dataset) "
+        _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
+        query = (f"MATCH (e:Entity)<-[:USED|WAS_GENERATED_BY*]-(t:Dataset) "
                  # The target entity can't be a Lab
                  f"WHERE e.uuid=$uuid AND e.entity_type <> 'Lab' "
-                 # COLLECT() returns a list
-                 # apoc.coll.toSet() reruns a set containing unique nodes
-                 f"RETURN apoc.coll.toSet(COLLECT(descendant)) AS {record_field_name}")
+                 f"{_activity_query_part} {record_field_name}")
 
     logger.info("======get_descendant_datasets() query======")
     logger.info(query)
@@ -790,17 +697,8 @@ def get_descendant_datasets(neo4j_driver, uuid, property_key=None):
         record = session.read_transaction(_execute_readonly_tx, query, uuid=uuid)
 
         if record and record[record_field_name]:
-            if property_key:
-                # Just return the list of property values from each entity node
-                results = record[record_field_name]
-            else:
-                # Convert the list of nodes to a list of dicts
-                results = _nodes_to_dicts(record[record_field_name])
-
-                for result in results:
-                    protocol_url = get_activity_protocol(neo4j_driver, result['uuid'])
-                    if protocol_url != {}:
-                        result['protocol_url'] = protocol_url
+            results = record[record_field_name]
+            schema.schema_manager.rearrange_datasets(results)
 
     return results
 
@@ -958,18 +856,17 @@ def get_parents(neo4j_driver, uuid, properties: Union[PropertyGroups, List[str]]
 
     is_filtered = isinstance(properties, PropertyGroups) or  isinstance(properties, list)
     if is_filtered:
-        _activity_query_part = schema_neo4j_queries.activity_query_part(properties)
+        _activity_query_part = schema_neo4j_queries.activity_query_part(properties if is_include_action else None)
         query = (f"MATCH (e:Entity)-[:WAS_GENERATED_BY]->(:Activity)-[:USED]->(t:Entity) "
                  # Filter out the Lab entities
                  f"WHERE e.uuid='{uuid}' AND t.entity_type <> 'Lab' {_activity_query_part[0]} "
                  f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
     else:
-        query = (f"MATCH (e:Entity)-[:WAS_GENERATED_BY]->(:Activity)-[:USED]->(parent:Entity) "
+        _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
+        query = (f"MATCH (e:Entity)-[:WAS_GENERATED_BY]->(:Activity)-[:USED]->(t:Entity) "
                  # Filter out the Lab entities
-                 f"WHERE e.uuid='{uuid}' AND parent.entity_type <> 'Lab' "
-                 # COLLECT() returns a list
-                 # apoc.coll.toSet() reruns a set containing unique nodes
-                 f"RETURN apoc.coll.toSet(COLLECT(parent)) AS {record_field_name}")
+                 f"WHERE e.uuid='{uuid}' AND t.entity_type <> 'Lab' "
+                 f"{_activity_query_part} {record_field_name}")
 
     logger.info("======get_parents() query======")
     logger.info(query)
@@ -978,12 +875,7 @@ def get_parents(neo4j_driver, uuid, properties: Union[PropertyGroups, List[str]]
         record = session.read_transaction(_execute_readonly_tx, query)
 
         if record and record[record_field_name]:
-            if is_filtered:
-                # Just return the list of property values from each entity node
-                results = record[record_field_name]
-            else:
-                # Convert the list of nodes to a list of dicts
-                results = _nodes_to_dicts(record[record_field_name])
+            results = record[record_field_name]
 
     return results
 
@@ -1013,18 +905,17 @@ def get_children(neo4j_driver, uuid, properties: Union[PropertyGroups, List[str]
 
     is_filtered = isinstance(properties, PropertyGroups) or  isinstance(properties, list)
     if is_filtered:
-        _activity_query_part = schema_neo4j_queries.activity_query_part(properties)
+        _activity_query_part = schema_neo4j_queries.activity_query_part(properties if is_include_action else None)
         query = (f"MATCH (e:Entity)<-[:USED]-(:Activity)<-[:WAS_GENERATED_BY]-(t:Entity) "
                  # The target entity can't be a Lab
                  f"WHERE e.uuid='{uuid}' AND e.entity_type <> 'Lab' {_activity_query_part[0]}"
                  f"{schema_neo4j_queries.exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
     else:
-        query = (f"MATCH (e:Entity)<-[:USED]-(:Activity)<-[:WAS_GENERATED_BY]-(child:Entity) "
+        _activity_query_part = schema_neo4j_queries.activity_query_part(for_all_match=True)
+        query = (f"MATCH (e:Entity)<-[:USED]-(:Activity)<-[:WAS_GENERATED_BY]-(t:Entity) "
                  # The target entity can't be a Lab
                  f"WHERE e.uuid='{uuid}' AND e.entity_type <> 'Lab' "
-                 # COLLECT() returns a list
-                 # apoc.coll.toSet() reruns a set containing unique nodes
-                 f"RETURN apoc.coll.toSet(COLLECT(child)) AS {record_field_name}")
+                 f"{_activity_query_part} {record_field_name}")
 
     logger.info("======get_children() query======")
     logger.info(query)
@@ -1033,12 +924,7 @@ def get_children(neo4j_driver, uuid, properties: Union[PropertyGroups, List[str]
         record = session.read_transaction(_execute_readonly_tx, query)
 
         if record and record[record_field_name]:
-            if is_filtered:
-                # Just return the list of property values from each entity node
-                results = record[record_field_name]
-            else:
-                # Convert the list of nodes to a list of dicts
-                results = _nodes_to_dicts(record[record_field_name])
+            results = record[record_field_name]
 
     return results
 

--- a/src/lib/property_groups.py
+++ b/src/lib/property_groups.py
@@ -1,5 +1,22 @@
 class PropertyGroups:
     def __init__(self, n, t, a, d, j, l):
+        """
+
+        Parameters
+        ----------
+        n : List[str]
+            Neo4j properties list
+        t : List[str]
+            Trigger (on_read_trigger) properties list
+        a : List[str]
+            Activity properties list
+        d : List[str]
+            Dependency properties list
+        j : List[str]
+            Schema yaml type:json_str properties list
+        l : List[str]
+            Schema yaml type:list properties list
+        """
         self.neo4j = n
         self.trigger = t
         self.activity = a

--- a/src/lib/property_groups.py
+++ b/src/lib/property_groups.py
@@ -1,0 +1,6 @@
+class PropertyGroups:
+    def __init__(self, n, t, a, d):
+        self.neo4j = n
+        self.trigger = t
+        self.activity = a
+        self.dependency = d

--- a/src/lib/property_groups.py
+++ b/src/lib/property_groups.py
@@ -1,6 +1,8 @@
 class PropertyGroups:
-    def __init__(self, n, t, a, d):
+    def __init__(self, n, t, a, d, j, l):
         self.neo4j = n
         self.trigger = t
         self.activity = a
         self.dependency = d
+        self.json = j
+        self.list = l

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1200,7 +1200,22 @@ def normalize_entities_list_for_response(entities_list:List, properties_to_exclu
     return normalized_entities_list
 
 
-def remove_unauthorized_fields_from_response(entities_list:List, unauthorized):
+def remove_unauthorized_fields_from_response(entities_list:List, unauthorized:bool):
+    """
+    If a user is unauthorized fields listed in excluded_properties_from_public_response under the respective
+    schema yaml will be removed from the results
+
+    Parameters
+    ----------
+    entities_list : List[dict]
+        The list to be potentially filtered
+    unauthorized : bool
+        Whether user is authorized or not
+
+    Returns
+    -------
+    List[dict]
+    """
     if unauthorized:
         filtered_final_result = []
         for entity in entities_list:

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -21,6 +21,10 @@ from schema import schema_neo4j_queries
 
 # Atlas Consortia commons
 from atlas_consortia_commons.rest import abort_bad_req
+from atlas_consortia_commons.string import equals
+from typing import List
+
+from lib.ontology import Ontology
 
 logger = logging.getLogger(__name__)
 
@@ -369,6 +373,24 @@ def get_schema_defaults(properties, is_include_action = True, target_entity_type
 
     return defaults
 
+def rearrange_datasets(results, entity_type = 'Dataset'):
+    """
+    If asked for the descendants of a Dataset then sort by last_modified_timestamp and place the published dataset at the top
+
+    :param results : List[dict]
+    :param entity_type : str
+    :return:
+    """
+    if isinstance(results[0], str) is False and equals(entity_type,  Ontology.ops().entities().DATASET):
+        results = sorted(results, key=lambda d: d['last_modified_timestamp'], reverse=True)
+
+        published_processed_dataset_location = next(
+            (i for i, item in enumerate(results) if item["status"] == "Published"), None)
+        if published_processed_dataset_location and published_processed_dataset_location != 0:
+            published_processed_dataset = results.pop(published_processed_dataset_location)
+            results.insert(0, published_processed_dataset)
+
+
 def group_verify_properties_list(normalized_class='All', properties=[]):
     """ Separates neo4j properties from transient ones. Will also gather specific property dependencies via a
     `dependency_properties` list setting in the schema yaml. Also filters out any unknown properties.
@@ -391,7 +413,7 @@ def group_verify_properties_list(normalized_class='All', properties=[]):
     defaults = get_schema_defaults([])
 
     if len(properties) == 1 and properties[0] in defaults:
-        return properties, [], []
+       return PropertyGroups(properties, [], [], [])
 
     neo4j_fields = []
     trigger_fields = []
@@ -1152,7 +1174,13 @@ list
 """
 
 
-def normalize_entities_list_for_response(entities_list, properties_to_exclude=[], properties_to_include=[]):
+def normalize_entities_list_for_response(entities_list:List, properties_to_exclude=[], properties_to_include=[]):
+    if len(entities_list) <= 0:
+        return []
+
+    if isinstance(entities_list[0], str):
+        return entities_list
+
     normalized_entities_list = []
 
     for entity_dict in entities_list:

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1219,11 +1219,10 @@ def remove_unauthorized_fields_from_response(entities_list:List, unauthorized:bo
     if unauthorized:
         filtered_final_result = []
         for entity in entities_list:
-            entity_entity_type = entity.get('entity_type')
-            fields_to_exclude = get_fields_to_exclude(entity_entity_type)
+            entity_type = entity.get('entity_type')
+            fields_to_exclude = get_fields_to_exclude(entity_type)
             filtered_entity = exclude_properties_from_response(fields_to_exclude, entity)
             filtered_final_result.append(filtered_entity)
-
         return filtered_final_result
     else:
         return entities_list

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -413,11 +413,13 @@ def group_verify_properties_list(normalized_class='All', properties=[]):
     defaults = get_schema_defaults([])
 
     if len(properties) == 1 and properties[0] in defaults:
-       return PropertyGroups(properties, [], [], [])
+       return PropertyGroups(properties, [], [], [], [], [])
 
     neo4j_fields = []
     trigger_fields = []
     activity_fields = []
+    json_fields = []
+    list_fields = []
     schema_section = {}
     activities_schema_section = {}
     dependencies = set()
@@ -447,13 +449,20 @@ def group_verify_properties_list(normalized_class='All', properties=[]):
                 trigger_fields.append(p)
             else:
                 neo4j_fields.append(p)
+
+                if 'type' in schema_section[p]:
+                    if schema_section[p]['type'] == 'json_string':
+                        json_fields.append(p)
+                    if schema_section[p]['type'] == 'list':
+                        list_fields.append(p)
+
         if p in activities_schema_section:
             activity_fields.append(p)
 
     if 'entity_type' not in neo4j_fields and len(trigger_fields) > 0:
         neo4j_fields.append('entity_type')
 
-    return PropertyGroups(neo4j_fields, trigger_fields, activity_fields, list(dependencies))
+    return PropertyGroups(neo4j_fields, trigger_fields, activity_fields, list(dependencies), json_fields, list_fields)
 
 def exclude_properties_from_response(excluded_fields, output_dict):
     """Removes specified fields from an existing dictionary.

--- a/src/schema/schema_manager.py
+++ b/src/schema/schema_manager.py
@@ -1200,6 +1200,19 @@ def normalize_entities_list_for_response(entities_list:List, properties_to_exclu
     return normalized_entities_list
 
 
+def remove_unauthorized_fields_from_response(entities_list:List, unauthorized):
+    if unauthorized:
+        filtered_final_result = []
+        for entity in entities_list:
+            entity_entity_type = entity.get('entity_type')
+            fields_to_exclude = get_fields_to_exclude(entity_entity_type)
+            filtered_entity = exclude_properties_from_response(fields_to_exclude, entity)
+            filtered_final_result.append(filtered_entity)
+
+        return filtered_final_result
+    else:
+        return entities_list
+
 """
 Validate json data from user request against the schema
 

--- a/src/schema/schema_neo4j_queries.py
+++ b/src/schema/schema_neo4j_queries.py
@@ -805,11 +805,11 @@ list
 def get_collection_entities(neo4j_driver, uuid, properties: Union[PropertyGroups, List[str]] = None, is_include_action: bool = True):
     results = []
 
-    _activity_query_part = activity_query_part(properties)
+    _activity_query_part = activity_query_part(properties if is_include_action else None)
     query = (f"MATCH (t:Entity)-[:IN_COLLECTION]->(c:Collection|Epicollection) "
              f"WHERE c.uuid = '{uuid}' {_activity_query_part[0]} "
-             f"{exclude_include_query_part(properties, is_include_action, more_to_grab_query_part=_activity_query_part)}")
-             #f"RETURN apoc.coll.toSet(COLLECT(e)) AS {record_field_name}")
+             f"{exclude_include_query_part(properties.neo4j + properties.dependency, is_include_action, more_to_grab_query_part=_activity_query_part)}")
+
 
     logger.info("======get_collection_entities() query======")
     logger.info(query)
@@ -818,11 +818,7 @@ def get_collection_entities(neo4j_driver, uuid, properties: Union[PropertyGroups
         record = session.read_transaction(_execute_readonly_tx, query)
 
         if record and record[record_field_name]:
-            if isinstance(properties, list):
-                results = record[record_field_name]
-            else:
-                # Convert the list of nodes to a list of dicts
-                results = _nodes_to_dicts(record[record_field_name])
+            results = record[record_field_name]
 
     return results
 
@@ -2208,11 +2204,21 @@ def get_sources_associated_entity(neo4j_driver, uuid, filter_out = None):
     return results
 
 
-def activity_query_part(properties):
+def activity_query_part(properties = None, for_all_match = False):
+    """
+    Builds activity query part(s) for grabbing properties like protocol_url from Activity
+
+    :param properties: PropertyGroups
+    :param for_all_match: bool
+    :return: Union[str,tuple[str,str,str]]
+    """
+    query_match_part = f"MATCH (e2:Entity)-[:WAS_GENERATED_BY]->(a:Activity) WHERE e2.uuid = t.uuid"
+
+    if for_all_match:
+        query_match_part = query_match_part + f" WITH t, apoc.map.fromPairs([['protocol_url', a.protocol_url]]) as a2 WITH apoc.map.merge(t,a2) as x RETURN apoc.coll.toSet(COLLECT(x)) AS "
+        return query_match_part
+
     if isinstance(properties, PropertyGroups) and len(properties.activity) > 0:
-
-        query_match_part = (f"MATCH (e2:Entity)-[:WAS_GENERATED_BY]->(a:Activity) WHERE e2.uuid = t.uuid")
-
         query_grab_part = ''
         for p in properties.activity:
             query_grab_part = query_grab_part + f", ['{p}', a.{p}]"
@@ -2222,7 +2228,7 @@ def activity_query_part(properties):
         return '', '', ''
 
 
-def exclude_include_query_part(properties:List[str], is_include_action = True, target_entity_type = 'Any', more_to_grab_query_part=None):
+def exclude_include_query_part(properties:Union[PropertyGroups, List[str]], is_include_action = True, target_entity_type = 'Any', more_to_grab_query_part=None):
     """
     Builds a cypher query part that can be used to include or exclude certain properties.
     The preceding MATCH query part should have a label 't'. E.g. MATCH (t:Entity)-[*]->(s:Source)
@@ -2243,21 +2249,25 @@ def exclude_include_query_part(properties:List[str], is_include_action = True, t
     str
         the inclusion exclusion query part to be applied with a MATCH query part
     """
+    if isinstance(properties, PropertyGroups):
+        _properties = properties.neo4j + properties.dependency
+    else:
+        _properties = properties
 
-    if is_include_action and len(properties) == 1 and properties[0] in ['uuid']:
-        return f"RETURN apoc.coll.toSet(COLLECT(t.{properties[0]})) AS {record_field_name}"
+    if is_include_action and len(_properties) == 1 and _properties[0] in ['uuid']:
+        return f"RETURN apoc.coll.toSet(COLLECT(t.{_properties[0]})) AS {record_field_name}"
 
     action = ''
     if is_include_action is False:
         action = 'NOT'
 
-    schema.schema_manager.get_schema_defaults(properties, is_include_action, target_entity_type)
+    schema.schema_manager.get_schema_defaults(_properties, is_include_action, target_entity_type)
     a = more_to_grab_query_part[2]
 
                    # unwind the keys of the results from target/t
     query_part = (f"WITH keys(t) AS k1, t{a} unwind k1 AS k2 "
                   # filter by a list[] of properties
-                  f"WITH t{a}, k2 WHERE {action} k2 IN {properties} "
+                  f"WITH t{a}, k2 WHERE {action} k2 IN {_properties} "
                   # everything is unwinded as separate rows, so let's build it back up by uuid to form: {prop: val, uuid:uuidVal}
                   f"WITH t{a}, apoc.map.fromPairs([[k2, t[k2]], ['uuid', t.uuid]{more_to_grab_query_part[1]}]) AS dict "
                   # collect all these individual dicts as a list[], and then group them by uuids, 

--- a/src/schema/schema_neo4j_queries.py
+++ b/src/schema/schema_neo4j_queries.py
@@ -2208,9 +2208,16 @@ def activity_query_part(properties = None, for_all_match = False):
     """
     Builds activity query part(s) for grabbing properties like protocol_url from Activity
 
-    :param properties: PropertyGroups
-    :param for_all_match: bool
-    :return: Union[str,tuple[str,str,str]]
+    Parameters
+    ----------
+    properties : PropertyGroups
+    for_all_match : bool
+
+    Returns
+    -------
+    Union[str, tuple[str,str,str]]
+        A string if using a grab all query, OR
+        tuple for exclude_include_query_part with [0] Additional MATCH, [1] map pair builds, [2] and 'a' variable to use in WITH statements
     """
     query_match_part = f"MATCH (e2:Entity)-[:WAS_GENERATED_BY]->(a:Activity) WHERE e2.uuid = t.uuid"
 

--- a/src/schema/schema_neo4j_queries.py
+++ b/src/schema/schema_neo4j_queries.py
@@ -1041,7 +1041,7 @@ def get_upload_datasets(neo4j_driver, uuid, query_filter='', properties: List[st
     """
     results = []
 
-    if len(properties) > 0:
+    if isinstance(properties, list):
         query = (f"MATCH (t:Dataset)-[:IN_UPLOAD]->(s:Upload) "
                  f"WHERE s.uuid = '{uuid}' {query_filter} "
                  f"{exclude_include_query_part(properties, is_include_action, target_entity_type = 'Dataset')}")

--- a/src/schema/schema_neo4j_queries.py
+++ b/src/schema/schema_neo4j_queries.py
@@ -2235,7 +2235,7 @@ def exclude_include_query_part(properties:Union[PropertyGroups, List[str]], is_i
 
     Parameters
     ----------
-    properties : List[str]
+    properties : Union[PropertyGroups, List[str]]
         the properties to be filtered
     is_include_action : bool
         whether to include or exclude the listed properties

--- a/src/schema/schema_neo4j_queries.py
+++ b/src/schema/schema_neo4j_queries.py
@@ -2262,14 +2262,15 @@ def exclude_include_query_part(properties:Union[PropertyGroups, List[str]], is_i
         action = 'NOT'
 
     schema.schema_manager.get_schema_defaults(_properties, is_include_action, target_entity_type)
-    a = more_to_grab_query_part[2]
+    a = more_to_grab_query_part[2] if isinstance(more_to_grab_query_part, tuple) else ''
+    map_pairs_part = more_to_grab_query_part[1] if isinstance(more_to_grab_query_part, tuple) else ''
 
                    # unwind the keys of the results from target/t
     query_part = (f"WITH keys(t) AS k1, t{a} unwind k1 AS k2 "
                   # filter by a list[] of properties
                   f"WITH t{a}, k2 WHERE {action} k2 IN {_properties} "
                   # everything is unwinded as separate rows, so let's build it back up by uuid to form: {prop: val, uuid:uuidVal}
-                  f"WITH t{a}, apoc.map.fromPairs([[k2, t[k2]], ['uuid', t.uuid]{more_to_grab_query_part[1]}]) AS dict "
+                  f"WITH t{a}, apoc.map.fromPairs([[k2, t[k2]], ['uuid', t.uuid]{map_pairs_part}]) AS dict "
                   # collect all these individual dicts as a list[], and then group them by uuids, 
                   # which forms a dict with uuid as keys and list of dicts as values: 
                   # {uuidVal: [{prop: val, uuid:uuidVal}, {prop2: val2, uuid:uuidVal}, ... {propN: valN, uuid:uuidVal}], uuidVal2: [...]}

--- a/src/schema/schema_neo4j_queries.py
+++ b/src/schema/schema_neo4j_queries.py
@@ -2211,13 +2211,15 @@ def activity_query_part(properties = None, for_all_match = False):
     Parameters
     ----------
     properties : PropertyGroups
+        The properties that will be used to build additional query parts
     for_all_match : bool
+        Whether to return a query part used for grabbing the entire nodes list
 
     Returns
     -------
     Union[str, tuple[str,str,str]]
         A string if using a grab all query, OR
-        tuple for exclude_include_query_part with [0] Additional MATCH, [1] map pair builds, [2] and 'a' variable to use in WITH statements
+        tuple for exclude_include_query_part with [0] Additional MATCH, [1] map pair query parts for apoc.map.fromPairs, [2] and 'a' variable to use in WITH statements
     """
     query_match_part = f"MATCH (e2:Entity)-[:WAS_GENERATED_BY]->(a:Activity) WHERE e2.uuid = t.uuid"
 
@@ -2235,6 +2237,21 @@ def activity_query_part(properties = None, for_all_match = False):
         return '', '', ''
 
 def property_type_query_part(properties:PropertyGroups, is_include_action = True):
+    """
+    Builds property type query part(s) for parsing properties of certain types
+
+    Parameters
+    ----------
+    properties : PropertyGroups
+        The properties that will be used to build additional query parts
+    is_include_action : bool
+        whether to include or exclude the listed properties
+
+    Returns
+    -------
+    str
+        The query part(s) for concatenation into apoc.map.fromPairs method
+    """
     if is_include_action is False:
         return ''
 
@@ -2262,7 +2279,7 @@ def build_additional_query_parts(properties:PropertyGroups, is_include_action = 
     Returns
     -------
     tuple[str,str,str]
-        [0] Additional MATCH, [1] map pair builds, [2] and variables to use in WITH statements
+        [0] Additional MATCH, [1] map pair query parts for apoc.map.fromPairs, [2] and variables to use in WITH statements
     """
     _activity_query_part = activity_query_part(properties if is_include_action else None)
     _property_type_query_part = property_type_query_part(properties, is_include_action)

--- a/src/schema/schema_neo4j_queries.py
+++ b/src/schema/schema_neo4j_queries.py
@@ -807,7 +807,7 @@ def get_collection_entities(neo4j_driver, uuid, properties: Union[PropertyGroups
 
     query = (f"MATCH (t:Entity)-[:IN_COLLECTION]->(c:Collection|Epicollection) "
              f"WHERE c.uuid = '{uuid}' "
-             f"{exclude_include_query_part(properties.neo4j + properties.dependency, is_include_action)}")
+             f"{exclude_include_query_part(properties, is_include_action)}")
 
 
     logger.info("======get_collection_entities() query======")
@@ -2242,6 +2242,21 @@ def property_type_query_part(properties:PropertyGroups, is_include_action = True
     return map_parts
 
 def build_additional_query_parts(properties:PropertyGroups, is_include_action = True):
+    """
+    Builds additional query parts to be concatenated with other query
+
+    Parameters
+    ----------
+    properties : PropertyGroups
+        The properties that will be used to build additional query parts
+    is_include_action : bool
+        whether to include or exclude the listed properties
+
+    Returns
+    -------
+    tuple[str,str,str]
+        [0] Additional MATCH, [1] map pair builds, [2] and variables to use in WITH statements
+    """
     _activity_query_part = activity_query_part(properties if is_include_action else None)
     _property_type_query_part = property_type_query_part(properties, is_include_action)
 

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -671,8 +671,8 @@ def get_normalized_collection_entities(uuid: str, token: str, skip_completion: b
     """
     db = schema_manager.get_neo4j_driver_instance()
     segregated_properties = schema_manager.group_verify_properties_list(properties=properties)
-    neo4j_properties = segregated_properties[0] + segregated_properties[2]
-    entities_list = schema_neo4j_queries.get_collection_entities(db, uuid, properties=neo4j_properties, is_include_action=is_include_action)
+    neo4j_properties = segregated_properties.neo4j + segregated_properties.dependency
+    entities_list = schema_neo4j_queries.get_collection_entities(db, uuid, properties=segregated_properties, is_include_action=is_include_action)
 
     if len(neo4j_properties) == 1 and neo4j_properties[0] == 'uuid':
         return entities_list

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1464,7 +1464,7 @@ def get_cedar_mapped_metadata(property_key, normalized_type, user_token, existin
         # For mouse sources, samples
         if 'metadata' not in existing_data_dict:
             return property_key, None
-        if not isinstance(existing_data_dict['ingest_metadata'], dict):
+        if not isinstance(existing_data_dict['metadata'], dict):
             metadata = ast.literal_eval(existing_data_dict['metadata'])
         else:
             metadata = existing_data_dict['metadata']

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1464,7 +1464,10 @@ def get_cedar_mapped_metadata(property_key, normalized_type, user_token, existin
         # For mouse sources, samples
         if 'metadata' not in existing_data_dict:
             return property_key, None
-        metadata = ast.literal_eval(existing_data_dict['metadata'])
+        if not isinstance(existing_data_dict['ingest_metadata'], dict):
+            metadata = ast.literal_eval(existing_data_dict['metadata'])
+        else:
+            metadata = existing_data_dict['metadata']
 
     mapped_metadata = {}
     for k, v in metadata.items():

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1448,7 +1448,7 @@ def get_cedar_mapped_metadata(property_key, normalized_type, user_token, existin
 
     if equals(Ontology.ops().entities().DATASET, normalized_type):
         # For datasets
-        if 'ingest_metadata' not in existing_data_dict:
+        if 'ingest_metadata' not in existing_data_dict or existing_data_dict['ingest_metadata'] is None:
             return property_key, None
 
         if not isinstance(existing_data_dict['ingest_metadata'], dict):
@@ -1462,7 +1462,7 @@ def get_cedar_mapped_metadata(property_key, normalized_type, user_token, existin
         metadata = ingest_metadata['metadata']
     else:
         # For mouse sources, samples
-        if 'metadata' not in existing_data_dict:
+        if 'metadata' not in existing_data_dict or existing_data_dict['metadata'] is None:
             return property_key, None
         if not isinstance(existing_data_dict['metadata'], dict):
             metadata = ast.literal_eval(existing_data_dict['metadata'])

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1374,7 +1374,7 @@ def get_source_mapped_metadata(property_key, normalized_type, user_token, existi
     """
     if not equals(Ontology.ops().source_types().HUMAN, existing_data_dict['source_type']):
         return property_key, None
-    if 'metadata' not in existing_data_dict:
+    if 'metadata' not in existing_data_dict or existing_data_dict['metadata'] is None:
         return property_key, None
 
     if (

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -686,7 +686,7 @@ def get_normalized_collection_entities(uuid: str, token: str, skip_completion: b
                                                                            is_include_action=is_include_action)
 
     return schema_manager.normalize_entities_list_for_response(entities_list=complete_entities_list,
-                                                               properties_to_exclude=[] if is_include_action else properties)
+                                                               properties_to_exclude=[] if is_include_action else properties, properties_to_include=segregated_properties.activity)
 
 
 def get_publication_associated_collection(property_key, normalized_type, user_token, existing_data_dict, new_data_dict):


### PR DESCRIPTION
Change log:
1. Allow for grabbing of protocol_url via an integrated cypher query rather than multiple single calls to `get_activity_protocol`
2. Any list_str or json_str requested in the filters are parsed with the cypher query allowing for that property to not be handled within `normalize_entities_list_for_response`