### PR TITLE
Fix issue with trigger and int value calling len()

### DIFF
--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1477,6 +1477,7 @@ def get_cedar_mapped_metadata(property_key, normalized_type, user_token, existin
     except Exception as e:
         msg = f"Failed to call the trigger method: get_cedar_mapped_metadata {existing_data_dict['uuid']}"
         logger.exception(f"{msg} {str(e)}")
+        mapped_metadata['Error'] = 'This metadata may be incomplete. If you continue to see this error message, please contact the SenNet Help Desk help@sennetconsortium.org.'
         return property_key, mapped_metadata
 
     return property_key, mapped_metadata

--- a/src/schema/schema_triggers.py
+++ b/src/schema/schema_triggers.py
@@ -1454,25 +1454,30 @@ def get_cedar_mapped_metadata(property_key, normalized_type, user_token, existin
         metadata = existing_data_dict['metadata']
 
     mapped_metadata = {}
-    for k, v in metadata.items():
-        suffix = None
-        parts = [_normalize(word) for word in k.split('_')]
-        if parts[-1] == 'Value' or parts[-1] == 'Unit':
-            suffix = parts.pop()
+    try:
+        for k, v in metadata.items():
+            suffix = None
+            parts = [_normalize(word) for word in k.split('_')]
+            if parts[-1] == 'Value' or parts[-1] == 'Unit':
+                suffix = parts.pop()
 
-        new_key = ' '.join(parts)
-        if new_key not in mapped_metadata:
-            mapped_metadata[new_key] = v
-        else:
-            curr_val = mapped_metadata[new_key]
-            if len(curr_val) < 1:
-                # Prevent space at the beginning if the value is empty
+            new_key = ' '.join(parts)
+            if new_key not in mapped_metadata:
                 mapped_metadata[new_key] = v
-                continue
-            if suffix == 'Value':
-                mapped_metadata[new_key] = f"{v} {curr_val}"
-            if suffix == 'Unit':
-                mapped_metadata[new_key] = f"{curr_val} {v}"
+            else:
+                curr_val = str(mapped_metadata[new_key])
+                if len(curr_val) < 1:
+                    # Prevent space at the beginning if the value is empty
+                    mapped_metadata[new_key] = v
+                    continue
+                if suffix == 'Value':
+                    mapped_metadata[new_key] = f"{v} {curr_val}"
+                if suffix == 'Unit':
+                    mapped_metadata[new_key] = f"{curr_val} {v}"
+    except Exception as e:
+        msg = f"Failed to call the trigger method: get_cedar_mapped_metadata {existing_data_dict['uuid']}"
+        logger.exception(f"{msg} {str(e)}")
+        return property_key, mapped_metadata
 
     return property_key, mapped_metadata
 


### PR DESCRIPTION
Change log:
1. Change value to `str` as seems a str is expected with call of `len` on `curr_val`
2. Wrap in `try/except` for any other unexpected issues. It will return what was processed before the exception in which case the value of `cedar_mapped_metadata` may be incomplete to the user. Don't know if we want to rethink that or leave it.