### PR TITLE
Tjmadonna/public id removal

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3273,6 +3273,10 @@ def get_associated_samples_from_dataset(id):
     _final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
     final_result = schema_manager.remove_unauthorized_fields_from_response(_final_result, unauthorized=not user_in_sennet_read_group(request))
 
+    if user_in_sennet_read_group(request) and public_entity:
+        fields_to_exclude = schema_manager.get_fields_to_exclude('Sample')
+        final_result = schema_manager.exclude_properties_from_response(fields_to_exclude, final_result)
+
     return jsonify(final_result)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -3186,7 +3186,6 @@ def get_associated_organs_from_dataset(id):
     # Use the internal token to query the target entity
     # since public entities don't require user token
     token = get_internal_token()
-    excluded_fields = schema_manager.get_fields_to_exclude('Sample')
     public_entity = True
 
     # published/public datasets don't require token
@@ -3210,6 +3209,7 @@ def get_associated_organs_from_dataset(id):
     final_result = schema_manager.normalize_entities_list_for_response(complete_entities_list)
 
     if public_entity and not user_in_sennet_read_group(request):
+        excluded_fields = schema_manager.get_fields_to_exclude('Sample')
         filtered_organs_list = []
         for organ in final_result:
             filtered_organs_list.append(schema_manager.exclude_properties_from_response(excluded_fields, organ))

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -975,6 +975,10 @@ ENTITIES:
     excluded_properties_from_public_response:
       - <<: *shared_excluded_properties_from_public_response
       - lab_tissue_sample_id
+      - direct_ancestor:
+          - lab_tissue_sample_id
+          - origin_samples:
+              - lab_tissue_sample_id
       - origin_samples:
           - lab_tissue_sample_id
       - source:

--- a/src/schema/provenance_schema.yaml
+++ b/src/schema/provenance_schema.yaml
@@ -976,11 +976,19 @@ ENTITIES:
       - <<: *shared_excluded_properties_from_public_response
       - lab_tissue_sample_id
       - direct_ancestor:
+          - lab_source_id
           - lab_tissue_sample_id
           - origin_samples:
+              - lab_source_id
               - lab_tissue_sample_id
+              - source:
+                  - lab_source_id
       - origin_samples:
           - lab_tissue_sample_id
+          - direct_ancestor:
+              - lab_source_id
+          - source:
+              - lab_source_id
       - source:
           - lab_source_id
     properties:


### PR DESCRIPTION
Changes
- Removed `lab_*` properties from `datasets/<uuid>/samples` and `datasets/<uuid>/organs` endpoints 